### PR TITLE
Revamp mobile UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="theme-color" content="#ff6f61">
   <title>Paper Plates</title>
   <link rel="stylesheet" href="./src/styles/styles.css">
   <link

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -2,7 +2,7 @@
 body {
   font-family: Arial, sans-serif;
   margin: 0;
-  padding: 0;
+  padding: 0 10px;
   background: #f9f9f9;
   color: #333;
 }
@@ -28,7 +28,7 @@ header {
   padding: 8px 12px;
   font-size: 14px;
   cursor: pointer;
-  border-radius: 5px;
+  border-radius: 8px;
   transition: background-color 0.3s, color 0.3s;
 }
 
@@ -43,12 +43,24 @@ header {
   background-color: #ff6f61;
   color: white;
   border: none;
-  border-radius: 5px;
+  border-radius: 8px;
   font-size: 14px;
   cursor: pointer;
   transition: all 0.3s ease-in-out;
   display: inline-block;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+#googleSignInBtn {
+  width: 100%;
+  padding: 12px;
+  border: none;
+  border-radius: 8px;
+  background-color: #ff6f61;
+  color: #fff;
+  font-size: 16px;
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 #copyLinkBtn:hover {
@@ -61,15 +73,16 @@ header {
   background-color: #ff6f61;
   color: white;
   border: none;
-  padding: 10px 20px;
-  border-radius: 5px;
+  padding: 12px;
+  border-radius: 8px;
   cursor: pointer;
   font-size: 16px;
-  margin: 20px auto;
+  margin: 20px 0;
   display: block;
   text-align: center;
   box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
   transition: background-color 0.3s ease-in-out;
+  width: 100%;
 }
 
 #toggleFormBtn:hover {
@@ -141,21 +154,28 @@ header {
 
 /* Form Container */
 #form-container {
-  max-width: 500px;
-  margin: 20px auto;
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
   background: white;
-  padding: 20px;
-  border-radius: 8px;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  padding: 15px 20px 20px;
+  border-top-left-radius: 15px;
+  border-top-right-radius: 15px;
+  box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: none;
+  margin: 0;
+  z-index: 1000;
 }
 
 #form-container input,
 #form-container textarea,
 #form-container select {
-  width: calc(100% - 20px);
+  width: 100%;
   padding: 10px;
   margin: 10px 0;
-  border-radius: 5px;
+  border-radius: 8px;
   border: 1px solid #ccc;
   font-size: 14px;
 }
@@ -166,7 +186,7 @@ header {
   background: #ff6f61;
   color: white;
   border: none;
-  border-radius: 5px;
+  border-radius: 8px;
   cursor: pointer;
   font-size: 16px;
   margin-top: 10px;
@@ -183,22 +203,30 @@ header {
 #plate {
   max-width: 600px;
   margin: 20px auto;
-  text-align: center;
-  padding: 20px;
-  background: white;
-  border-radius: 8px;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  text-align: left;
+  padding: 20px 0 220px;
   position: relative;
-  min-height: 200px;
 }
 
 .note {
   margin: 10px 0;
   padding: 15px;
-  border-radius: 5px;
-  background: #ffefc1;
-  text-align: center;
+  border-radius: 10px;
+  background: #ffffff;
+  text-align: left;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.note .music-button {
+  display: block;
+  margin-top: 10px;
+  width: 100%;
+  padding: 8px;
+  border: none;
+  border-radius: 8px;
+  background-color: #ff6f61;
+  color: #fff;
+  font-size: 14px;
 }
 
 .note .message {
@@ -331,10 +359,8 @@ footer {
   padding: 15px 0;
   font-size: 14px;
   border-top: 2px solid #e65b55; /* Optional: adds a slight border at the top */
-  position: fixed; /* Sticks the footer to the bottom */
   width: 100%;
-  bottom: 0;
-  box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.1); /* Adds a subtle shadow */
+  margin-top: 40px;
 }
 
 footer a {


### PR DESCRIPTION
## Summary
- redesign styles for a more mobile-friendly feel
- float the note form at the bottom like a chat box
- add full width buttons and card-style notes
- tweak theme color

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ed0155a34833387469404a7879ee7