### PR TITLE
Refine mobile color picker layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="theme-color" content="#ff6f61">
   <title>Paper Plates</title>
   <link rel="stylesheet" href="./src/styles/styles.css">
   <link
@@ -42,57 +43,73 @@
         <ul id="recipientSuggestions" style="display: none;"></ul>
       </div>
       <textarea id="message" placeholder="Write your note"></textarea>
-      <div class="picker-container">
-      <label for="fontPicker">Choose Font:</label>
-      <select id="fontPicker">
-        <option value="Arial" style="font-family: Arial;">Arial</option>
-        <option value="'Courier New', Courier" style="font-family: 'Courier New', Courier;">Courier New</option>
-        <option value="'Dancing Script', cursive" style="font-family: 'Dancing Script', cursive;">Dancing Script</option>
-        <option value="'Pacifico', cursive" style="font-family: 'Pacifico', cursive;">Pacifico</option>
-        <option value="'Great Vibes', cursive" style="font-family: 'Great Vibes', cursive;">Great Vibes</option>
-        <option value="Georgia" style="font-family: Georgia;">Georgia</option>
-      </select>
-      </div>  
-      <div class="font-size-container">
-        <label for="fontSizePicker" class="picker-label">Font Size:</label>
-        <select id="fontSizePicker">
-          <option value="12px">Small</option>
-          <option value="16px" selected>Medium</option>
-          <option value="20px">Large</option>
-          <option value="24px">Extra Large</option>
-        </select> 
-      </div>       
-
-      <div class="color-picker-container">
-        <button id="toggleBgSliders" class="color-picker-label">
-          <i class="fa fa-palette" aria-hidden="true"></i>
-        </button>
-        <div id="bgSliders" class="sliders-container">
-          <p class="color-helper-text">Adjust the background color sliders!</p>
-          <label for="bgRedSlider">Red</label>
-          <input type="range" id="bgRedSlider" min="0" max="255" value="255">
-          <label for="bgGreenSlider">Green</label>
-          <input type="range" id="bgGreenSlider" min="0" max="255" value="239">
-          <label for="bgBlueSlider">Blue</label>
-          <input type="range" id="bgBlueSlider" min="0" max="255" value="193">
+      <div id="themeSection" class="theme-section">
+        <label class="theme-title">Choose a Theme</label>
+        <div class="theme-options">
+          <button class="theme-card selected" data-bg="#ffffff" data-text="#000000" data-font="Arial, sans-serif" data-size="16px">
+            <span class="theme-sample" style="background-color:#ffffff;color:#000000;font-family:Arial;">Aa</span>
+            <span class="theme-name">Classic</span>
+          </button>
+          <button class="theme-card" data-bg="#ffe4e1" data-text="#b22222" data-font="'Great Vibes', cursive" data-size="18px">
+            <span class="theme-sample" style="background-color:#ffe4e1;color:#b22222;font-family:'Great Vibes',cursive;">Aa</span>
+            <span class="theme-name">Romantic</span>
+          </button>
+          <button class="theme-card" data-bg="#ffeb3b" data-text="#ff5722" data-font="'Comic Sans MS', cursive, sans-serif" data-size="18px">
+            <span class="theme-sample" style="background-color:#ffeb3b;color:#ff5722;font-family:'Comic Sans MS',cursive;">Aa</span>
+            <span class="theme-name">Playful</span>
+          </button>
+          <button class="theme-card" data-bg="#e0f7fa" data-text="#006064" data-font="Helvetica, sans-serif" data-size="16px">
+            <span class="theme-sample" style="background-color:#e0f7fa;color:#006064;font-family:Helvetica;">Aa</span>
+            <span class="theme-name">Modern</span>
+          </button>
         </div>
-        <label for="toggleBgSliders" class="color-helper-text">Set Background Color</label>
       </div>
-      
-      <div class="color-picker-container">
-        <button id="toggleTextSliders" class="color-picker-label">
-          <i class="fa fa-eyedropper" aria-hidden="true"></i>
-        </button>
-        <div id="textSliders" class="sliders-container">
-          <p class="color-helper-text">Adjust the text color sliders!</p>
-          <label for="textRedSlider">Red</label>
-          <input type="range" id="textRedSlider" min="0" max="255" value="0">
-          <label for="textGreenSlider">Green</label>
-          <input type="range" id="textGreenSlider" min="0" max="255" value="0">
-          <label for="textBlueSlider">Blue</label>
-          <input type="range" id="textBlueSlider" min="0" max="255" value="0">
+      <button id="customizeBtn" class="customize-btn">Customize</button>
+      <div id="customizeSection" style="display:none;">
+        <div class="picker-container">
+          <label for="fontPicker">Choose Font:</label>
+          <select id="fontPicker">
+            <option value="Arial" style="font-family: Arial;">Arial</option>
+            <option value="'Courier New', Courier" style="font-family: 'Courier New', Courier;">Courier New</option>
+            <option value="'Dancing Script', cursive" style="font-family: 'Dancing Script', cursive;">Dancing Script</option>
+            <option value="'Pacifico', cursive" style="font-family: 'Pacifico', cursive;">Pacifico</option>
+            <option value="'Great Vibes', cursive" style="font-family: 'Great Vibes', cursive;">Great Vibes</option>
+            <option value="Georgia" style="font-family: Georgia;">Georgia</option>
+          </select>
         </div>
-        <label for="toggleTextSliders" class="color-helper-text">Set Text Color</label>
+        <div class="font-size-container">
+          <label for="fontSizePicker" class="picker-label">Font Size:</label>
+          <select id="fontSizePicker">
+            <option value="12px">Small</option>
+            <option value="16px" selected>Medium</option>
+            <option value="20px">Large</option>
+            <option value="24px">Extra Large</option>
+          </select>
+        </div>
+        <div class="color-picker-container">
+          <label class="color-picker-title">Choose Background Color</label>
+          <div id="bgColorOptions" class="color-options">
+            <button class="color-circle bg-color-option" data-color="#ffc0cb" style="background-color:#ffc0cb"></button>
+            <button class="color-circle bg-color-option" data-color="#fff39b" style="background-color:#fff39b"></button>
+            <button class="color-circle bg-color-option" data-color="#add8e6" style="background-color:#add8e6"></button>
+            <button class="color-circle bg-color-option" data-color="#e6e6fa" style="background-color:#e6e6fa"></button>
+            <button class="color-circle bg-color-option" data-color="#b2dfdb" style="background-color:#b2dfdb"></button>
+            <input type="color" id="bgCustomPicker" class="color-circle bg-color-option" />
+          </div>
+          <input type="hidden" id="notesColorPicker" value="#ffffff">
+        </div>
+        <div class="color-picker-container">
+          <label class="color-picker-title">Choose Text Color</label>
+          <div id="textColorOptions" class="color-options">
+            <button class="color-circle text-color-option" data-color="#ffc0cb" style="background-color:#ffc0cb"></button>
+            <button class="color-circle text-color-option" data-color="#fff39b" style="background-color:#fff39b"></button>
+            <button class="color-circle text-color-option" data-color="#add8e6" style="background-color:#add8e6"></button>
+            <button class="color-circle text-color-option" data-color="#e6e6fa" style="background-color:#e6e6fa"></button>
+            <button class="color-circle text-color-option" data-color="#b2dfdb" style="background-color:#b2dfdb"></button>
+            <input type="color" id="textCustomPicker" class="color-circle text-color-option" />
+          </div>
+          <input type="hidden" id="textColorPicker" value="#000000">
+        </div>
       </div>
 
       <input type="text" id="music" placeholder="Add a song link (optional, but highly recommended!)">

--- a/src/app.js
+++ b/src/app.js
@@ -19,17 +19,14 @@ const fontPicker = document.getElementById("fontPicker");
 const fontSizePicker = document.getElementById("fontSizePicker");
 const loadingSpinner = document.getElementById("loadingSpinner");
 
-const bgRedSlider = document.getElementById("bgRedSlider");
-const bgGreenSlider = document.getElementById("bgGreenSlider");
-const bgBlueSlider = document.getElementById("bgBlueSlider");
 const notesColorPicker = document.getElementById("notesColorPicker");
-const notesColorPickerLabel = document.querySelector('label[for="notesColorPicker"]');
-
-const textRedSlider = document.getElementById("textRedSlider");
-const textGreenSlider = document.getElementById("textGreenSlider");
-const textBlueSlider = document.getElementById("textBlueSlider");
 const textColorPicker = document.getElementById("textColorPicker");
-const textColorPickerLabel = document.querySelector('label[for="textColorPicker"]');
+const recipientSearch = document.getElementById("recipientSearch");
+const themeCards = document.querySelectorAll(".theme-card");
+const customizeBtn = document.getElementById("customizeBtn");
+const customizeSection = document.getElementById("customizeSection");
+const bgCustomPicker = document.getElementById("bgCustomPicker");
+const textCustomPicker = document.getElementById("textCustomPicker");
 
 // Firebase Google Sign-In Provider
 const provider = new GoogleAuthProvider();
@@ -85,7 +82,6 @@ auth.onAuthStateChanged((user) => {
           console.log("Fetched recipient data:", recipient);
 
           // Populate recipient name
-          const recipientSearch = document.getElementById("recipientSearch");
           recipientSearch.value = recipient.name;
           recipientSearch.dataset.selectedUid = recipientUid;
           previewRecipient.textContent = recipient.name;
@@ -210,7 +206,6 @@ function updateUIForAnonymousUser() {
  * Updates Firebase dynamically and notifies the user.
  */
 document.addEventListener("DOMContentLoaded", () => {
-  const recipientSearch = document.getElementById("recipientSearch");
   recipientSuggestions.addEventListener("click", (event) => {
   const selectedText = event.target.textContent;
 
@@ -221,6 +216,7 @@ document.addEventListener("DOMContentLoaded", () => {
         .then(() => {
           alert(`"${newRecipient}" has been added to the recipient list.`);
           recipientSuggestions.style.display = "none"; // Hide suggestions
+          updatePreview();
         })
         .catch((error) => {
           console.error("Error adding recipient:", error);
@@ -321,18 +317,40 @@ function resetForm() {
   recipientSearch.value = "";
   delete recipientSearch.dataset.selectedUid; // Clear stored UID
   messageInput.value = "";
-  notesColorPicker.value = "#000000";
-  textColorPicker.value = "#ffffff";
-  fontPicker.value = "'Arial', sans-serif";
+  notesColorPicker.value = "#ffffff";
+  textColorPicker.value = "#000000";
+  fontPicker.value = "Arial, sans-serif";
   fontSizePicker.value = "16px";
   musicInput.value = "";
 
-  previewNote.style.backgroundColor = "#000000";
-  previewNote.style.color = "#ffffff";
+  previewNote.style.backgroundColor = "#ffffff";
+  previewNote.style.color = "#000000";
   previewNote.style.fontFamily = "Arial";
   previewNote.style.fontSize = "16px";
   previewRecipient.textContent = "Recipient's Name";
   previewMessage.textContent = "Your message will appear here.";
+
+  document.querySelectorAll(".bg-color-option").forEach((btn) =>
+    btn.classList.remove("selected")
+  );
+  document.querySelectorAll(".text-color-option").forEach((btn) =>
+    btn.classList.remove("selected")
+  );
+}
+
+function updatePreview() {
+  previewRecipient.textContent =
+    recipientSearch.value.trim() || "Recipient's Name";
+  previewMessage.textContent =
+    messageInput.value.trim() || "Your message will appear here.";
+  notePreview.style.backgroundColor = notesColorPicker.value;
+  notePreview.style.color = textColorPicker.value;
+  notePreview.style.fontFamily = fontPicker.value;
+  notePreview.style.fontSize = fontSizePicker.value;
+
+  notePreview.classList.remove("fade-anim");
+  void notePreview.offsetWidth;
+  notePreview.classList.add("fade-anim");
 }
 
 /**
@@ -344,7 +362,6 @@ function resetForm() {
 
 // Recipient name input
 document.addEventListener("DOMContentLoaded", () => {
-  const recipientSearch = document.getElementById("recipientSearch");
 
   if (recipientSearch) {
     recipientSearch.addEventListener(
@@ -380,6 +397,7 @@ document.addEventListener("DOMContentLoaded", () => {
                   recipientSearch.value = recipient.name; // Set name in input
                   recipientSearch.dataset.selectedUid = uid; // Store selected UID
                   recipientSuggestions.style.display = "none"; // Hide dropdown
+                  updatePreview();
                 });
                 recipientSuggestions.appendChild(li);
               });
@@ -411,61 +429,6 @@ messageInput.addEventListener("input", (e) => {
 });
 });
 
-document.addEventListener("DOMContentLoaded", () => {
-  const toggleBgSliders = document.getElementById("toggleBgSliders");
-  const bgSliders = document.getElementById("bgSliders");
-  const toggleTextSliders = document.getElementById("toggleTextSliders");
-  const textSliders = document.getElementById("textSliders");
-
-  const updateBackgroundColor = () => {
-    const red = bgRedSlider.value;
-    const green = bgGreenSlider.value;
-    const blue = bgBlueSlider.value;
-    const rgbColor = `rgb(${red}, ${green}, ${blue})`;
-
-    toggleBgSliders.style.backgroundColor = rgbColor;
-    previewNote.style.backgroundColor = rgbColor;
-  };
-
-  const updateTextColor = () => {
-    const red = textRedSlider.value;
-    const green = textGreenSlider.value;
-    const blue = textBlueSlider.value;
-    const rgbColor = `rgb(${red}, ${green}, ${blue})`;
-
-    toggleTextSliders.style.backgroundColor = rgbColor;
-    previewNote.style.color = rgbColor;
-  };
-
-  // Add toggle functionality
-  toggleBgSliders.addEventListener("click", () => {
-    bgSliders.style.display =
-      bgSliders.style.display === "none" || !bgSliders.style.display
-        ? "block"
-        : "none";
-  });
-
-  toggleTextSliders.addEventListener("click", () => {
-    textSliders.style.display =
-      textSliders.style.display === "none" || !textSliders.style.display
-        ? "block"
-        : "none";
-  });
-
-  // Add color update functionality
-  bgRedSlider.addEventListener("input", updateBackgroundColor);
-  bgGreenSlider.addEventListener("input", updateBackgroundColor);
-  bgBlueSlider.addEventListener("input", updateBackgroundColor);
-  textRedSlider.addEventListener("input", updateTextColor);
-  textGreenSlider.addEventListener("input", updateTextColor);
-  textBlueSlider.addEventListener("input", updateTextColor);
-
-  // Initialize styles
-  bgSliders.style.display = "none";
-  textSliders.style.display = "none";
-  updateBackgroundColor();
-  updateTextColor();
-});
 
 
 
@@ -597,24 +560,66 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
-  // Update the preview content dynamically as users type
-  recipientSearch.addEventListener("input", (e) => {
-    const recipientName = e.target.value.trim();
-    document.getElementById("previewRecipient").innerText = recipientName || "Recipient's Name";
+  recipientSearch.addEventListener("input", updatePreview);
+  messageInput.addEventListener("input", updatePreview);
+  notesColorPicker.addEventListener("input", updatePreview);
+  textColorPicker.addEventListener("input", updatePreview);
+  fontPicker.addEventListener("change", updatePreview);
+  fontSizePicker.addEventListener("change", updatePreview);
+});
+
+// Setup color circle pickers
+document.addEventListener("DOMContentLoaded", () => {
+  function setupColorOptions(selector, picker) {
+    const options = document.querySelectorAll(selector);
+    options.forEach((opt) => {
+      const type = opt.tagName.toLowerCase() === "input" ? "input" : "click";
+      opt.addEventListener(type, () => {
+        options.forEach((o) => o.classList.remove("selected"));
+        if (type === "click") opt.classList.add("selected");
+        picker.value = opt.dataset.color || opt.value;
+        updatePreview();
+      });
+    });
+  }
+
+  setupColorOptions(".bg-color-option", notesColorPicker);
+  setupColorOptions(".text-color-option", textColorPicker);
+  updatePreview();
+});
+
+// Theme selection and customize flow
+document.addEventListener("DOMContentLoaded", () => {
+  themeCards.forEach((card) => {
+    card.addEventListener("click", () => {
+      themeCards.forEach((c) => c.classList.remove("selected"));
+      card.classList.add("selected");
+      notesColorPicker.value = card.dataset.bg;
+      textColorPicker.value = card.dataset.text;
+      fontPicker.value = card.dataset.font;
+      fontSizePicker.value = card.dataset.size;
+      updatePreview();
+    });
   });
 
-  messageInput.addEventListener("input", (e) => {
-    const message = e.target.value.trim();
-    document.getElementById("previewMessage").innerText = message || "Your message will appear here.";
-  });
+  if (customizeBtn && customizeSection) {
+    customizeBtn.addEventListener("click", () => {
+      customizeSection.style.display = "block";
+      customizeBtn.style.display = "none";
+    });
+  }
 
-  notesColorPicker.addEventListener("input", (e) => {
-    const selectedColor = e.target.value;
-    notePreview.style.backgroundColor = selectedColor;
-  });
+  if (bgCustomPicker) {
+    bgCustomPicker.addEventListener("input", () => {
+      notesColorPicker.value = bgCustomPicker.value;
+      updatePreview();
+    });
+  }
 
-  textColorPicker.addEventListener("input", (e) => {
-    const selectedColor = e.target.value;
-    notePreview.style.color = selectedColor;
-  });
+  if (textCustomPicker) {
+    textCustomPicker.addEventListener("input", () => {
+      textColorPicker.value = textCustomPicker.value;
+      updatePreview();
+    });
+  }
 });

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -1,4 +1,10 @@
 /* General Styling */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
 body {
   font-family: Arial, sans-serif;
   margin: 0;
@@ -28,7 +34,7 @@ header {
   padding: 8px 12px;
   font-size: 14px;
   cursor: pointer;
-  border-radius: 5px;
+  border-radius: 8px;
   transition: background-color 0.3s, color 0.3s;
 }
 
@@ -43,12 +49,24 @@ header {
   background-color: #ff6f61;
   color: white;
   border: none;
-  border-radius: 5px;
+  border-radius: 8px;
   font-size: 14px;
   cursor: pointer;
   transition: all 0.3s ease-in-out;
   display: inline-block;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+#googleSignInBtn {
+  width: 100%;
+  padding: 12px;
+  border: none;
+  border-radius: 8px;
+  background-color: #ff6f61;
+  color: #fff;
+  font-size: 16px;
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 #copyLinkBtn:hover {
@@ -61,15 +79,16 @@ header {
   background-color: #ff6f61;
   color: white;
   border: none;
-  padding: 10px 20px;
-  border-radius: 5px;
+  padding: 12px;
+  border-radius: 8px;
   cursor: pointer;
   font-size: 16px;
-  margin: 20px auto;
+  margin: 20px 0;
   display: block;
   text-align: center;
   box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
   transition: background-color 0.3s ease-in-out;
+  width: 100%;
 }
 
 #toggleFormBtn:hover {
@@ -141,35 +160,45 @@ header {
 
 /* Form Container */
 #form-container {
-  max-width: 500px;
-  margin: 20px auto;
-  background: white;
-  padding: 20px;
-  border-radius: 8px;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: #fafafa;
+  padding: 15px 20px 20px;
+  border-top-left-radius: 15px;
+  border-top-right-radius: 15px;
+  box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: none;
+  margin: 0 auto;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 #form-container input,
 #form-container textarea,
 #form-container select {
-  width: calc(100% - 20px);
-  padding: 10px;
-  margin: 10px 0;
-  border-radius: 5px;
+  width: 100%;
+  padding: 12px;
+  border-radius: 8px;
   border: 1px solid #ccc;
   font-size: 14px;
+  box-sizing: border-box;
 }
 
 #form-container button {
   width: 100%;
-  padding: 10px;
+  padding: 12px;
   background: #ff6f61;
   color: white;
   border: none;
-  border-radius: 5px;
+  border-radius: 8px;
   cursor: pointer;
   font-size: 16px;
-  margin-top: 10px;
+  margin: 0;
   transition: all 0.3s ease-in-out;
 }
 
@@ -183,22 +212,30 @@ header {
 #plate {
   max-width: 600px;
   margin: 20px auto;
-  text-align: center;
-  padding: 20px;
-  background: white;
-  border-radius: 8px;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  text-align: left;
+  padding: 20px 0 220px;
   position: relative;
-  min-height: 200px;
 }
 
 .note {
   margin: 10px 0;
   padding: 15px;
-  border-radius: 5px;
-  background: #ffefc1;
-  text-align: center;
+  border-radius: 10px;
+  background: #ffffff;
+  text-align: left;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.note .music-button {
+  display: block;
+  margin-top: 10px;
+  width: 100%;
+  padding: 8px;
+  border: none;
+  border-radius: 8px;
+  background-color: #ff6f61;
+  color: #fff;
+  font-size: 14px;
 }
 
 .note .message {
@@ -221,57 +258,104 @@ header {
   gap: 10px;
 }
 
-.color-picker-label {
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  background-color: #f5f5f5;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-  cursor: pointer;
-}
-
-.color-picker-label:hover {
-  transform: scale(1.1);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-}
-
-.color-helper-text {
+.color-picker-title {
   font-size: 14px;
+  font-weight: bold;
   color: #555;
 }
 
-.sliders label {
-  font-size: 14px;
-  font-weight: bold;
+.color-options {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 10px;
+  overflow-x: auto;
+  padding-bottom: 5px;
+  -webkit-overflow-scrolling: touch;
+  scroll-behavior: smooth;
+}
+.color-options::-webkit-scrollbar {
+  display: none;
 }
 
-.sliders input[type="range"] {
-  width: 100%;
-  -webkit-appearance: none;
-  appearance: none;
-  height: 8px;
-  background: #ddd;
-  border-radius: 5px;
-  outline: none;
-}
-
-.sliders input[type="range"]::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  appearance: none;
-  width: 20px;
-  height: 20px;
+.color-circle {
+  flex: 0 0 auto;
+  width: 40px;
+  height: 40px;
   border-radius: 50%;
-  background: #ff6f61;
+  border: 2px solid transparent;
   cursor: pointer;
-  transition: background 0.3s;
 }
 
-.sliders input[type="range"]::-webkit-slider-thumb:hover {
-  background: #e65b55;
+.color-circle.selected {
+  border-color: #333;
+}
+
+/* Theme Selection */
+.theme-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.theme-options {
+  display: flex;
+  gap: 10px;
+  overflow-x: auto;
+  padding-bottom: 5px;
+  -webkit-overflow-scrolling: touch;
+}
+.theme-options::-webkit-scrollbar {
+  display: none;
+}
+
+.theme-card {
+  flex: 0 0 auto;
+  border: 2px solid transparent;
+  border-radius: 10px;
+  padding: 8px;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 80px;
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.theme-card.selected {
+  border-color: #ff6f61;
+}
+
+.theme-sample {
+  width: 100%;
+  border-radius: 6px;
+  padding: 6px 0;
+  margin-bottom: 4px;
+  font-weight: bold;
+  text-align: center;
+}
+
+.customize-btn {
+  background: #ff6f61;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 12px;
+  cursor: pointer;
+  font-size: 16px;
+}
+
+.customize-btn:hover {
+  background: #ff4500;
+}
+
+.fade-anim {
+  animation: fade 0.3s ease;
+}
+
+@keyframes fade {
+  from { opacity: 0.5; }
+  to { opacity: 1; }
 }
 
 .font-size-container{
@@ -331,10 +415,8 @@ footer {
   padding: 15px 0;
   font-size: 14px;
   border-top: 2px solid #e65b55; /* Optional: adds a slight border at the top */
-  position: fixed; /* Sticks the footer to the bottom */
   width: 100%;
-  bottom: 0;
-  box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.1); /* Adds a subtle shadow */
+  margin-top: 40px;
 }
 
 footer a {


### PR DESCRIPTION
## Summary
- make color swatches horizontally scrollable for better mobile usability
- add mobile-friendly theme selection cards
- allow customizing colors, fonts and size with a single preview update function

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ed0155a34833387469404a7879ee7