### PR TITLE
Add live preview tests

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -13,7 +13,13 @@ const messageInput = document.getElementById("message");
 const musicInput = document.getElementById("music");
 const toggleFormBtn = document.getElementById("toggleFormBtn");
 const formContainer = document.getElementById("form-container");
-const previewNote = document.getElementById("previewNote");
+const previewNote =
+  document.getElementById("previewNote") ||
+  document.getElementById("notePreview");
+// Several spots in the code reference either `previewNote` or `notePreview`.
+// Normalize both names to point at the same DOM element so tests and
+// existing code remain compatible regardless of which ID is present.
+const notePreview = previewNote;
 const recipientsRef = ref(database, "recipients");
 const fontPicker = document.getElementById("fontPicker");
 const fontSizePicker = document.getElementById("fontSizePicker");
@@ -323,10 +329,10 @@ function resetForm() {
   fontSizePicker.value = "16px";
   musicInput.value = "";
 
-  previewNote.style.backgroundColor = "#ffffff";
-  previewNote.style.color = "#000000";
-  previewNote.style.fontFamily = "Arial";
-  previewNote.style.fontSize = "16px";
+  notePreview.style.backgroundColor = "#ffffff";
+  notePreview.style.color = "#000000";
+  notePreview.style.fontFamily = "Arial";
+  notePreview.style.fontSize = "16px";
   previewRecipient.textContent = "Recipient's Name";
   previewMessage.textContent = "Your message will appear here.";
 
@@ -548,7 +554,6 @@ formContainer.style.display = "none";
 
 document.addEventListener("DOMContentLoaded", () => {
   const togglePreviewBtn = document.getElementById("togglePreviewBtn");
-  const notePreview = document.getElementById("notePreview");
 
   togglePreviewBtn.addEventListener("click", () => {
     if (notePreview.style.display === "none") {
@@ -641,3 +646,6 @@ document.addEventListener("DOMContentLoaded", () => {
   setupColorOptions(".bg-color-option", notesColorPicker);
   setupColorOptions(".text-color-option", textColorPicker);
 });
+
+// Export key functions for testing purposes
+export { resetForm, updatePreview, isValidURL };

--- a/tests/domUtils.test.js
+++ b/tests/domUtils.test.js
@@ -12,20 +12,29 @@ jest.mock("firebase/auth", () => ({
   });  
 
 test("resets form inputs and preview", () => {
-  // Mock DOM
   document.body.innerHTML = `
-  <div id="plate"></div>
-  <button id="addNoteBtn"></button>
-  <textarea id="message"></textarea>
-  <input id="notesColorPicker" type="color" />
-    `;
+    <input id="recipientSearch" />
+    <textarea id="message"></textarea>
+    <select id="fontPicker"><option value="Arial" selected>Arial</option></select>
+    <select id="fontSizePicker"><option value="16px" selected>16</option></select>
+    <input id="notesColorPicker" type="color" value="#123456" />
+    <input id="textColorPicker" type="color" value="#654321" />
+    <input id="music" />
+    <div id="notePreview"></div>`;
 
   resetForm();
 
+  const preview = document.getElementById("notePreview");
   expect(document.getElementById("recipientSearch").value).toBe("");
   expect(document.getElementById("message").value).toBe("");
-  expect(document.getElementById("notesColorPicker").value).toBe("#000000");
-  expect(document.getElementById("previewNote").style.backgroundColor).toBe("rgb(0, 0, 0)");
+  expect(document.getElementById("notesColorPicker").value).toBe("#ffffff");
+  expect(document.getElementById("textColorPicker").value).toBe("#000000");
+  expect(document.getElementById("fontPicker").value).toBe("Arial, sans-serif");
+  expect(document.getElementById("fontSizePicker").value).toBe("16px");
+  expect(preview.style.backgroundColor).toBe("rgb(255, 255, 255)");
+  expect(preview.style.color).toBe("rgb(0, 0, 0)");
+  expect(preview.style.fontFamily).toBe("Arial");
+  expect(preview.style.fontSize).toBe("16px");
 });
 
 beforeEach(() => {
@@ -41,7 +50,7 @@ beforeEach(() => {
       <div id="form-container"></div>
       <input id="recipientSearch" />
       <ul id="recipientSuggestions"></ul>
-      <div id="previewNote"></div>
+      <div id="notePreview"></div>
     `;
   });
   

--- a/tests/livePreview.test.js
+++ b/tests/livePreview.test.js
@@ -1,0 +1,89 @@
+import { jest } from '@jest/globals';
+
+// Mock Firebase modules used in app.js
+jest.mock('../src/firebase.js', () => ({
+  auth: {},
+  database: {},
+  ref: jest.fn(),
+  set: jest.fn(),
+  push: jest.fn(),
+  onValue: jest.fn(),
+  signInAnonymously: jest.fn(),
+}));
+
+jest.mock('firebase/auth', () => ({
+  GoogleAuthProvider: jest.fn(),
+  signInWithPopup: jest.fn(),
+}));
+
+describe('Live preview functionality', () => {
+  let updatePreview, resetForm;
+
+  beforeEach(async () => {
+    document.body.innerHTML = `
+      <input id="recipientSearch" />
+      <textarea id="message"></textarea>
+      <select id="fontPicker">
+        <option value="Arial, sans-serif">Arial</option>
+        <option value="Courier">Courier</option>
+      </select>
+      <select id="fontSizePicker">
+        <option value="16px">16</option>
+        <option value="24px">24</option>
+      </select>
+      <input id="notesColorPicker" type="color" value="#ffffff" />
+      <input id="textColorPicker" type="color" value="#000000" />
+      <input id="music" />
+      <div id="notePreview" style="display:block;">
+        <p id="previewRecipient"></p>
+        <p id="previewMessage"></p>
+      </div>`;
+    jest.resetModules();
+    const mod = await import('../src/app.js');
+    updatePreview = mod.updatePreview;
+    resetForm = mod.resetForm;
+  });
+
+  test('updatePreview reflects user inputs', () => {
+    document.getElementById('recipientSearch').value = 'Alice';
+    document.getElementById('message').value = 'Hello world';
+    document.getElementById('fontPicker').value = 'Courier';
+    document.getElementById('fontSizePicker').value = '24px';
+    document.getElementById('notesColorPicker').value = '#ff0000';
+    document.getElementById('textColorPicker').value = '#00ff00';
+
+    updatePreview();
+
+    const preview = document.getElementById('notePreview');
+    expect(preview.style.backgroundColor).toBe('rgb(255, 0, 0)');
+    expect(preview.style.color).toBe('rgb(0, 255, 0)');
+    expect(preview.style.fontFamily).toBe('Courier');
+    expect(preview.style.fontSize).toBe('24px');
+    expect(document.getElementById('previewRecipient').textContent).toBe('Alice');
+    expect(document.getElementById('previewMessage').textContent).toBe('Hello world');
+  });
+
+  test('resetForm restores defaults', () => {
+    document.getElementById('recipientSearch').value = 'Bob';
+    document.getElementById('message').value = 'Hi';
+    document.getElementById('fontPicker').value = 'Courier';
+    document.getElementById('fontSizePicker').value = '24px';
+    document.getElementById('notesColorPicker').value = '#123456';
+    document.getElementById('textColorPicker').value = '#654321';
+    updatePreview();
+
+    resetForm();
+
+    const preview = document.getElementById('notePreview');
+    expect(preview.style.backgroundColor).toBe('rgb(255, 255, 255)');
+    expect(preview.style.color).toBe('rgb(0, 0, 0)');
+    expect(preview.style.fontFamily).toBe('Arial');
+    expect(preview.style.fontSize).toBe('16px');
+    expect(document.getElementById('previewRecipient').textContent).toBe("Recipient's Name");
+    expect(document.getElementById('previewMessage').textContent).toBe('Your message will appear here.');
+    expect(document.getElementById('fontPicker').value).toBe('Arial, sans-serif');
+    expect(document.getElementById('fontSizePicker').value).toBe('16px');
+    expect(document.getElementById('notesColorPicker').value).toBe('#ffffff');
+    expect(document.getElementById('textColorPicker').value).toBe('#000000');
+  });
+});


### PR DESCRIPTION
## Summary
- export preview helpers from `src/app.js`
- normalize preview element access
- test dynamic preview and reset behavior

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ff866508883339476ef910013e88d