### PR TITLE
Add React world map demo with d3

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,6 +128,7 @@
       </div> 
     </section>
   </main>
+  <div id="root"></div>
   <footer>
     <p>&copy; 2025 Paper Plates. Made with Love 💚</p>
   </footer>

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "vite": "^6.0.5"
   },
   "dependencies": {
-    "firebase": "^11.1.0"
+    "firebase": "^11.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "d3": "^7.8.5"
   }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,17 @@
+.app svg {
+  width: 100%;
+  height: auto;
+}
+
+.tooltip {
+  background: rgba(0, 0, 0, 0.75);
+  color: #fff;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.8rem;
+}
+
+.tooltip a {
+  color: #aee;
+  text-decoration: underline;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import WorldMap from './components/WorldMap';
+import './App.css';
+
+function App() {
+  return (
+    <div className="app">
+      <WorldMap />
+    </div>
+  );
+}
+
+const rootEl = document.getElementById('root');
+if (rootEl) {
+  const root = ReactDOM.createRoot(rootEl);
+  root.render(<App />);
+}
+
+export default App;

--- a/src/components/WorldMap.js
+++ b/src/components/WorldMap.js
@@ -1,0 +1,96 @@
+import React, { useRef, useEffect } from 'react';
+import * as d3 from 'd3';
+import countries from '../data/countries.json';
+import relationships from '../data/relationships.json';
+
+/**
+ * WorldMap component
+ * Renders a graticule background using d3.geoNaturalEarth1
+ * Displays mock countries as blue circles and draws relationship lines
+ * Hovering a relationship shows a tooltip describing the connection
+ */
+function WorldMap() {
+  const svgRef = useRef(null);
+  const tooltipRef = useRef(null);
+
+  useEffect(() => {
+    const width = 800;
+    const height = 400;
+
+    const projection = d3.geoNaturalEarth1()
+      .scale(160)
+      .translate([width / 2, height / 2]);
+
+    const path = d3.geoPath().projection(projection);
+    const graticule = d3.geoGraticule();
+
+    const svg = d3.select(svgRef.current)
+      .attr('viewBox', `0 0 ${width} ${height}`)
+      .style('width', '100%')
+      .style('height', 'auto');
+
+    svg.append('path')
+      .datum(graticule())
+      .attr('fill', 'none')
+      .attr('stroke', '#ccc')
+      .attr('d', path);
+
+    // Render countries as circles
+    svg.selectAll('circle.country')
+      .data(countries)
+      .enter()
+      .append('circle')
+      .attr('class', 'country')
+      .attr('r', 5)
+      .attr('fill', 'steelblue')
+      .attr('cx', d => projection([d.lon, d.lat])[0])
+      .attr('cy', d => projection([d.lon, d.lat])[1]);
+
+    // Render relationships as lines
+    svg.selectAll('path.relationship')
+      .data(relationships)
+      .enter()
+      .append('path')
+      .attr('class', 'relationship')
+      .attr('stroke', d => d.color)
+      .attr('stroke-width', 2)
+      .attr('fill', 'none')
+      .attr('d', d => {
+        const source = countries.find(c => c.name === d.source);
+        const target = countries.find(c => c.name === d.target);
+        if (!source || !target) return null;
+        return d3.line()([
+          projection([source.lon, source.lat]),
+          projection([target.lon, target.lat])
+        ]);
+      })
+      .on('mouseover', (event, d) => {
+        const tooltip = d3.select(tooltipRef.current);
+        tooltip.style('display', 'block');
+        tooltip.style('left', `${event.pageX + 5}px`);
+        tooltip.style('top', `${event.pageY + 5}px`);
+        tooltip.html(
+          `<div class="title">${d.source} → ${d.target}</div>` +
+          `<div class="justification">${d.justification}</div>` +
+          (d.links && d.links.length
+            ? `<div class="links">${d.links.map(l => `<a href="${l}">${l}</a>`).join(', ')}</div>`
+            : '') +
+          (d.tags && d.tags.length
+            ? `<div class="tags">${d.tags.join(', ')}</div>`
+            : '')
+        );
+      })
+      .on('mouseout', () => {
+        d3.select(tooltipRef.current).style('display', 'none');
+      });
+  }, []);
+
+  return (
+    <div className="world-map-container" style={{ position: 'relative' }}>
+      <svg ref={svgRef}></svg>
+      <div ref={tooltipRef} className="tooltip" style={{ display: 'none', position: 'absolute' }} />
+    </div>
+  );
+}
+
+export default WorldMap;

--- a/src/data/countries.json
+++ b/src/data/countries.json
@@ -1,0 +1,5 @@
+[
+  { "name": "United States", "lat": 38, "lon": -97 },
+  { "name": "France", "lat": 46, "lon": 2 },
+  { "name": "Japan", "lat": 36, "lon": 138 }
+]

--- a/src/data/relationships.json
+++ b/src/data/relationships.json
@@ -1,0 +1,18 @@
+[
+  {
+    "source": "United States",
+    "target": "France",
+    "color": "green",
+    "justification": "Allied relationship",
+    "links": ["https://example.com/us-france"],
+    "tags": ["allies"]
+  },
+  {
+    "source": "United States",
+    "target": "Japan",
+    "color": "red",
+    "justification": "Trade tension",
+    "links": ["https://example.com/us-japan"],
+    "tags": ["trade", "tension"]
+  }
+]


### PR DESCRIPTION
## Summary
- add React-based `WorldMap` component
- create mock JSON data for countries and relationships
- render component via new `App.js`
- include minimal tooltip and svg styling
- insert React root in `index.html`
- document new dependencies: react, react-dom, d3

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68592193c0588333b744eaae3a44f31c